### PR TITLE
Add FormatHash to control proof output

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,33 @@
+use std::borrow::Cow;
+
+use ethers::types::Bytes;
+
+pub trait FormatHash {
+    type Out;
+
+    fn format(hash: Cow<Bytes>) -> Self::Out;
+}
+
+/// Format hashes as 0x prefixed hexadecimal string.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Hex0x;
+
+impl FormatHash for Hex0x {
+    type Out = String;
+
+    fn format(hash: Cow<Bytes>) -> Self::Out {
+        format!("0x{}", ethers::utils::hex::encode(hash.as_ref()))
+    }
+}
+
+/// Return hashes as bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Raw;
+
+impl FormatHash for Raw {
+    type Out = Bytes;
+
+    fn format(hash: Cow<Bytes>) -> Self::Out {
+        hash.into_owned()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod core;
+pub mod format;
 pub mod standard;


### PR DESCRIPTION
The PR adds a `FormatHash` trait that becomes a generic parameter of `StandardMerkleTree` with a default value of `Hex0x` and determines the output type of the `root` and `get_proof` methods. 

The motivation is that I wanted to keep data as binary rather than `String`, and it seems wasteful to format it just to parse it back immediately where I call these methods from.

The drawback is that some of the tests needed the type to be declared to give a hint to the compiler, but it's not too bad as `Hex0x` did not have to appear anywhere.