### PR TITLE
Return Result instead of panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Assume we're looking to generate a proof for the entry that corresponds to addre
 
         let tree_data: StandardMerkleTreeData = serde_json::from_str(&tree_json).unwrap();
 
-        let tree = StandardMerkleTree::load(tree_data);
+        let tree = StandardMerkleTree::load(tree_data).unwrap();
 
         for (i, v) in tree.clone().enumerate() {
         if v[0] == "0x1111111111111111111111111111111111111111" {
@@ -130,7 +130,7 @@ let values = vec![
         ],
     ];
     let encoding = ["address", "uint256"];
-    let tree = StandardMerkleTree::of(values, &encoding);
+    let tree = StandardMerkleTree::of(values, &encoding).unwrap();
 ```
 
 Creates a standard merkle tree out of an array of the elements in the tree, along with their types for ABI encoding.
@@ -162,7 +162,7 @@ Returns a description of the merkle tree for distribution. It contains all the n
 let tree_json = fs::read_to_string("tree.json").unwrap();
 let tree_data: StandardMerkleTreeData = serde_json::from_str(&tree_json).unwrap();
 
-let tree = StandardMerkleTree::load(tree_data);
+let tree = StandardMerkleTree::load(tree_data).unwrap();
 ```
 
 Loads the tree from a description previously returned by `dump`.
@@ -170,7 +170,7 @@ Loads the tree from a description previously returned by `dump`.
 ### `tree.getProof`
 
 ```rust
-let proof = tree.get_proof(LeafType::Number(i));
+let proof = tree.get_proof(LeafType::Number(i)).unwrap();
 ```
 
 Returns a proof for the `i`th value in the tree. Indices refer to the position of the values in the array from which the tree was constructed.
@@ -178,13 +178,13 @@ Returns a proof for the `i`th value in the tree. Indices refer to the position o
 It is wrapped in a `LeafType` enum of `Number(usize)` for indices and `LeafBytes(Vec<string>)` for values. Using value is less efficient cause it will fail if the value is not found in the tree.
 
 ```rust
-let proof = tree.getProof(LeafType::LeafBytes([alice, "100"]));
+let proof = tree.get_proof(LeafType::LeafBytes([alice, "100"])).unwrap();
 ```
 
 ### `tree.getMultiProof`
 
 ```rust
-let multi_proof = tree.getMultiProof([LeafType::Number(i0), LeafType::Number(i1), ...]);
+let multi_proof = tree.get_multi_proof([LeafType::Number(i0), LeafType::Number(i1), ...]).unwrap();
 ```
 
 Returns a multiproof strcut containing {proof, prooflags, leaves} for the values at indices `i0, i1, ...`. Indices refer to the position of the values in the array from which the tree was constructed.
@@ -198,7 +198,7 @@ Also accepts values instead of indices, but this will be less efficient. It will
 ```rust
 for (i, v) in tree.clone().enumerate {
   console.log("value: {:?}", v);
-  console.log("proof: {:?}", tree.getProof(LeafType::Number(i)));
+  console.log("proof: {:?}", tree.getProof(LeafType::Number(i)).unwrap());
 }
 ```
 
@@ -207,7 +207,7 @@ Lists the values in the tree along with their indices, which can be used to obta
 ### `tree.render`
 
 ```rust
-println!("{:?}", tree.render());
+println!("{:?}", tree.render().unwrap());
 ```
 
 Returns a visual representation of the tree that can be useful for debugging.
@@ -215,7 +215,7 @@ Returns a visual representation of the tree that can be useful for debugging.
 ### `tree.leafHash`
 
 ```rust
-let leaf = tree.leafHash(["alice".to_string(), "100".to_string()]);
+let leaf = tree.leaf_hash(["alice".to_string(), "100".to_string()]).unwrap();
 ```
 
 Returns the leaf hash of the value, as defined in [Standard Merkle Trees](#standard-merkle-trees).

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1,4 +1,4 @@
-use core::panic;
+use anyhow::{anyhow, bail, Result};
 use ethers::{
     abi::{
         self,
@@ -51,44 +51,46 @@ pub enum LeafType {
     LeafBytes(Vec<String>),
 }
 
-pub fn standard_leaf_hash(values: Vec<String>, params: &[String]) -> Bytes {
+pub fn standard_leaf_hash(values: Vec<String>, params: &[String]) -> Result<Bytes> {
     let tokens = params
         .iter()
         .enumerate()
         .map(|(i, p)| {
-            let param_type = Reader::read(p).unwrap();
+            let param_type = Reader::read(p)?;
 
-            LenientTokenizer::tokenize(&param_type, &values[i]).unwrap()
+            Ok(LenientTokenizer::tokenize(&param_type, &values[i])?)
         })
-        .collect::<Vec<Token>>();
-    Bytes::from(keccak256(keccak256(Bytes::from(abi::encode(&tokens)))))
+        .collect::<Result<Vec<Token>>>()?;
+    let hash = keccak256(keccak256(Bytes::from(abi::encode(&tokens))));
+    Ok(Bytes::from(hash))
 }
 
-pub fn check_bounds<T>(values: &[T], index: usize) {
+pub fn check_bounds<T>(values: &[T], index: usize) -> Result<()> {
     if index >= values.len() {
-        panic!("Index out of range")
+        bail!("Index out of range")
     }
+    Ok(())
 }
 
 impl StandardMerkleTree {
-    fn new(tree: Vec<Bytes>, values: Vec<Values>, leaf_encoding: Vec<String>) -> Self {
+    fn new(tree: Vec<Bytes>, values: Vec<Values>, leaf_encoding: Vec<String>) -> Result<Self> {
         let mut hash_lookup = HashMap::new();
-        values.iter().enumerate().for_each(|(i, v)| {
+        for (i, v) in values.iter().enumerate() {
             hash_lookup.insert(
-                hex::encode(standard_leaf_hash(v.value.clone(), &leaf_encoding)),
+                hex::encode(standard_leaf_hash(v.value.clone(), &leaf_encoding)?),
                 i,
             );
-        });
+        }
 
-        Self {
+        Ok(Self {
             hash_lookup,
             tree,
             values,
             leaf_encoding,
-        }
+        })
     }
 
-    pub fn of<V: ToString, E: ToString>(values: &[Vec<V>], leaf_encode: &[E]) -> Self {
+    pub fn of<V: ToString, E: ToString>(values: &[Vec<V>], leaf_encode: &[E]) -> Result<Self> {
         let values: Vec<Vec<String>> = values
             .iter()
             .map(|v| v.iter().map(|v| v.to_string()).collect())
@@ -97,16 +99,18 @@ impl StandardMerkleTree {
         let mut hashed_values: Vec<HashedValues> = values
             .iter()
             .enumerate()
-            .map(|(i, v)| HashedValues {
-                value: (*v).to_vec(),
-                value_index: i,
-                hash: standard_leaf_hash(v.clone(), &leaf_encode),
+            .map(|(i, v)| {
+                Ok(HashedValues {
+                    value: (*v).to_vec(),
+                    value_index: i,
+                    hash: standard_leaf_hash(v.clone(), &leaf_encode)?,
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         hashed_values.sort_by(|a, b| a.hash.cmp(&b.hash));
 
-        let tree = make_merkle_tree(hashed_values.iter().map(|v| v.hash.clone()).collect());
+        let tree = make_merkle_tree(hashed_values.iter().map(|v| v.hash.clone()).collect())?;
 
         let mut indexed_values: Vec<Values> = values
             .iter()
@@ -122,9 +126,9 @@ impl StandardMerkleTree {
         Self::new(tree, indexed_values, leaf_encode)
     }
 
-    pub fn load(data: StandardMerkleTreeData) -> StandardMerkleTree {
+    pub fn load(data: StandardMerkleTreeData) -> Result<StandardMerkleTree> {
         if data.format != "standard-v1" {
-            panic!("Unknown format");
+            bail!("Unknown format");
         }
 
         let tree = data
@@ -149,7 +153,7 @@ impl StandardMerkleTree {
         }
     }
 
-    pub fn render(&self) -> String {
+    pub fn render(&self) -> Result<String> {
         render_merkle_tree(&self.tree)
     }
 
@@ -157,79 +161,84 @@ impl StandardMerkleTree {
         format!("0x{}", hex::encode(&self.tree[0]))
     }
 
-    pub fn validate(&self) {
-        (0..self.values.len()).for_each(|i| self.validate_value(i))
+    pub fn validate(&self) -> Result<()> {
+        for i in 0..self.values.len() {
+            self.validate_value(i)?;
+        }
+        Ok(())
     }
 
-    pub fn leaf_hash(&self, leaf: &[&str]) -> String {
+    pub fn leaf_hash(&self, leaf: &[&str]) -> Result<String> {
         let leaf: Vec<String> = leaf.iter().map(|v| v.to_string()).collect();
-        format!(
+        Ok(format!(
             "0x{}",
-            hex::encode(standard_leaf_hash(leaf, &self.leaf_encoding))
-        )
+            hex::encode(standard_leaf_hash(leaf, &self.leaf_encoding)?)
+        ))
     }
 
-    pub fn leaf_lookup(&self, leaf: &[&str]) -> usize {
-        let binding = self.leaf_hash(leaf);
+    pub fn leaf_lookup(&self, leaf: &[&str]) -> Result<usize> {
+        let binding = self.leaf_hash(leaf)?;
         let leaf_hash = binding.split_at(2).1;
 
-        *self
-            .hash_lookup
+        self.hash_lookup
             .get(leaf_hash)
-            .expect("Leaf is not in tree")
+            .map(|i| *i)
+            .ok_or_else(|| anyhow!("Leaf is not in tree"))
     }
 
-    pub fn get_proof(&self, leaf: LeafType) -> Vec<String> {
+    pub fn get_proof(&self, leaf: LeafType) -> Result<Vec<String>> {
         let value_index = match leaf {
             LeafType::Number(i) => i,
             LeafType::LeafBytes(v) => {
-                self.leaf_lookup(&v.iter().map(|v| v.as_str()).collect::<Vec<&str>>())
+                self.leaf_lookup(&v.iter().map(|v| v.as_str()).collect::<Vec<&str>>())?
             }
         };
-        self.validate_value(value_index);
+        self.validate_value(value_index)?;
 
         // rebuild tree index and generate proof
         let value = self.values.get(value_index).unwrap();
-        let proof = get_proof(self.tree.clone(), value.tree_index);
+        let proof = get_proof(self.tree.clone(), value.tree_index)?;
 
         // check proof
         let hash = self.tree.get(value.tree_index).unwrap();
-        let implied_root = process_proof(hash, &proof);
+        let implied_root = process_proof(hash, &proof)?;
 
         if !implied_root.eq(self.tree.get(0).unwrap()) {
-            panic!("Unable to prove value")
+            bail!("Unable to prove value")
         }
 
-        proof
+        Ok(proof
             .iter()
             .map(|p| format!("0x{}", hex::encode(p)))
-            .collect()
+            .collect())
     }
 
-    pub fn get_multi_proof(&self, leaves: &[LeafType]) -> MultiProof<Vec<String>, String> {
-        let value_indices: Vec<usize> = leaves
+    pub fn get_multi_proof(&self, leaves: &[LeafType]) -> Result<MultiProof<Vec<String>, String>> {
+        let value_indices = leaves
             .iter()
             .map(|leaf| match leaf {
-                LeafType::Number(i) => *i,
+                LeafType::Number(i) => Ok(*i),
                 LeafType::LeafBytes(v) => {
                     self.leaf_lookup(&v.iter().map(|v| v.as_str()).collect::<Vec<&str>>())
                 }
             })
-            .collect();
+            .collect::<Result<Vec<usize>>>()?;
 
-        value_indices.iter().for_each(|i| self.validate_value(*i));
+        for i in value_indices.iter() {
+            self.validate_value(*i)?;
+        }
 
         // rebuild tree indices and generate proof
         let mut indices: Vec<usize> = value_indices
             .iter()
             .map(|i| self.values.get(*i).unwrap().tree_index)
             .collect();
-        let multi_proof = get_multi_proof(self.tree.clone(), &mut indices);
+        let multi_proof = get_multi_proof(self.tree.clone(), &mut indices)?;
 
         // check proof
-        let implied_root = process_multi_proof(&multi_proof);
+        let implied_root = process_multi_proof(&multi_proof)?;
         if !implied_root.eq(self.tree.get(0).unwrap()) {
-            panic!("Unable to prove value")
+            bail!("Unable to prove value")
         }
 
         let leaves: Vec<Vec<String>> = multi_proof
@@ -247,21 +256,22 @@ impl StandardMerkleTree {
             .map(|p| format!("0x{}", hex::encode(p)))
             .collect();
 
-        MultiProof {
+        Ok(MultiProof {
             leaves,
             proof,
             proof_flags: multi_proof.proof_flags,
-        }
+        })
     }
 
-    fn validate_value(&self, index: usize) {
-        check_bounds(&self.values, index);
+    fn validate_value(&self, index: usize) -> Result<()> {
+        check_bounds(&self.values, index)?;
         let value = self.values.get(index).unwrap();
-        check_bounds(&self.tree, value.tree_index);
-        let leaf = standard_leaf_hash(value.value.clone(), &self.leaf_encoding);
+        check_bounds(&self.tree, value.tree_index)?;
+        let leaf = standard_leaf_hash(value.value.clone(), &self.leaf_encoding)?;
         if !leaf.eq(self.tree.get(value.tree_index).unwrap()) {
-            panic!("Merkle tree does not contain the expected value")
+            bail!("Merkle tree does not contain the expected value")
         }
+        Ok(())
     }
 }
 
@@ -288,7 +298,7 @@ mod tests {
             .iter()
             .map(|v| v.iter().map(|v| v.as_str()).collect())
             .collect();
-        let t = StandardMerkleTree::of(&values, &["string"]);
+        let t = StandardMerkleTree::of(&values, &["string"]).unwrap();
         (l, t)
     }
 
@@ -298,7 +308,8 @@ mod tests {
             "0x1111111111111111111111111111111111111111".to_string(),
             "5000000000000000000".to_string(),
         ];
-        let hash = standard_leaf_hash(values, &["address".to_string(), "uint".to_string()]);
+        let hash =
+            standard_leaf_hash(values, &["address".to_string(), "uint".to_string()]).unwrap();
         let expected_hash: Bytes = [
             235, 2, 196, 33, 207, 164, 137, 118, 230, 109, 251, 41, 18, 7, 69, 144, 158, 163, 160,
             248, 67, 69, 108, 38, 60, 248, 241, 37, 52, 131, 226, 131,
@@ -321,7 +332,7 @@ mod tests {
             ],
         ];
 
-        let merkle_tree = StandardMerkleTree::of(&values, &["address", "uint256"]);
+        let merkle_tree = StandardMerkleTree::of(&values, &["address", "uint256"]).unwrap();
         let expected_tree = vec![
             "0xd4dee0beab2d53f2cc83e567171bd2820e49898130a22622b10ead383e90bd77",
             "0xeb02c421cfa48976e66dfb29120745909ea3a0f843456c263cf8f1253483e283",
@@ -334,7 +345,7 @@ mod tests {
     #[test]
     fn test_validate() {
         let (_, t) = characters("abcdef");
-        t.validate();
+        t.validate().unwrap();
     }
 
     #[test]
@@ -342,8 +353,8 @@ mod tests {
         let (_, t) = characters("abcdef");
 
         for (i, v) in t.clone().enumerate() {
-            let proof = t.get_proof(LeafType::Number(i));
-            let proof2 = t.get_proof(LeafType::LeafBytes(v));
+            let proof = t.get_proof(LeafType::Number(i)).unwrap();
+            let proof2 = t.get_proof(LeafType::LeafBytes(v)).unwrap();
 
             assert_eq!(proof, proof2);
         }
@@ -369,12 +380,12 @@ mod tests {
 
         leaves_array.iter().for_each(|ids| {
             let leaves: Vec<LeafType> = ids.iter().map(|i| LeafType::Number(*i)).collect();
-            let proof = t.get_multi_proof(&leaves);
+            let proof = t.get_multi_proof(&leaves).unwrap();
             let leaves: Vec<LeafType> = ids
                 .iter()
                 .map(|i| LeafType::LeafBytes(l[*i].clone()))
                 .collect();
-            let proof2 = t.get_multi_proof(&leaves);
+            let proof2 = t.get_multi_proof(&leaves).unwrap();
 
             assert_eq!(proof, proof2);
         })
@@ -392,15 +403,15 @@ mod tests {
 │  └─ 4) 0x19ba6c6333e0e9a15bf67523e0676e2f23eb8e574092552d5e888c64a4bb3681
 └─ 2) 0x9cf5a63718145ba968a01c1d557020181c5b252f665cf7386d370eddb176517b";
 
-        assert_eq!(t.render(), expected);
+        assert_eq!(t.render().unwrap(), expected);
     }
 
     #[test]
     fn test_dump_load() {
         let (_, t) = characters("abcdef");
-        let t2 = StandardMerkleTree::load(t.dump());
+        let t2 = StandardMerkleTree::load(t.dump()).unwrap();
 
-        t2.validate();
+        t2.validate().unwrap();
         assert_eq!(t, t2);
     }
 
@@ -417,7 +428,7 @@ mod tests {
     #[should_panic = "Index out of range"]
     fn test_out_of_bounds_panic() {
         let (_, t) = characters("a");
-        t.get_proof(LeafType::Number(1));
+        t.get_proof(LeafType::Number(1)).unwrap();
     }
 
     #[test]
@@ -428,7 +439,8 @@ mod tests {
             tree: Vec::new(),
             values: Vec::new(),
             leaf_encoding: Vec::new(),
-        });
+        })
+        .unwrap();
     }
 
     #[test]
@@ -443,9 +455,10 @@ mod tests {
                 tree_index: 0,
             }],
             leaf_encoding: vec!["uint256".to_string()],
-        });
+        })
+        .unwrap();
 
-        t.get_proof(LeafType::Number(0));
+        t.get_proof(LeafType::Number(0)).unwrap();
     }
 
     #[test]
@@ -463,8 +476,9 @@ mod tests {
                 tree_index: 2,
             }],
             leaf_encoding: vec!["uint256".to_string()],
-        });
+        })
+        .unwrap();
 
-        t.get_proof(LeafType::Number(0));
+        t.get_proof(LeafType::Number(0)).unwrap();
     }
 }


### PR DESCRIPTION
Changed all `panic!`s (I hope) to return `anyhow::Result`, which seemed to have been the established pattern at some point. 

This should make it safer to use this library with untrusted source of data. It should be okay the way it is, but it requires care for everyone to know how to use it safely and crashing is a scary prospect.